### PR TITLE
Update Composer requirements. Module works on PHP 7.1.x and 7.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mageworkshop/module-shopping-cart-notifications",
     "description": "MageWorkshop Shopping Cart Notifications for the customer to clearly know if the item was successfully added to the Shopping Cart",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
         "magento/module-catalog": "*",
         "magento/framework": "*",
         "magento/magento-composer-installer": "*"


### PR DESCRIPTION
Update Composer requirements. Module works on PHP 7.1.x and 7.2.x as well. Please merge this commit in order to avoid composer messages.